### PR TITLE
Add VS Code configuration backup and restore script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Welcome to **script-a-lot**, a public repository of shell scripts that I've crea
 ### 1. [gh-forks-cleanup](./gh-forks-cleanup)
 A Bash script to help you clean up unused GitHub forks. If you have a lot of forked repositories cluttering your GitHub account, this script can assist in identifying and removing the ones you no longer need.
 
+### 2. [vscode-config-mgmt](./vscode-config-mgmt)
+A cross-platform Bash script for backing up and restoring Visual Studio Code configuration. It automatically detects your operating system (macOS or Linux) and backs up your settings, keybindings, installed extensions, and code snippets. Perfect for syncing your VS Code setup across different machines or before system reinstalls.
+
 
 ## License
 

--- a/vscode-config-mgmt/vscode-config-mgmt.sh
+++ b/vscode-config-mgmt/vscode-config-mgmt.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# Script to backup and restore VS Code configuration
+
+# --- Configuration ---
+BACKUP_DIR="$HOME/Documents/vscode_backup"  # Directory to store backups
+
+# Detect OS and set appropriate paths
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS
+    VSCODE_USER_DIR="$HOME/Library/Application Support/Code/User"
+else
+    # Linux
+    VSCODE_USER_DIR="$HOME/.config/Code/User"
+fi
+
+SETTINGS_FILE="$VSCODE_USER_DIR/settings.json"
+KEYBINDINGS_FILE="$VSCODE_USER_DIR/keybindings.json"
+JAVASCRIPT_SNIPPETS="$VSCODE_USER_DIR/snippets/javascript.json"
+EXTENSIONS_FILE="$BACKUP_DIR/vscode_extensions.txt"
+
+# --- Functions ---
+
+backup_config() {
+  echo "Backing up VS Code configuration to $BACKUP_DIR..."
+
+  # Create backup directory if it doesn't exist
+  mkdir -p "$BACKUP_DIR"
+
+  # Backup settings
+  if [ -f "$SETTINGS_FILE" ]; then
+    cp "$SETTINGS_FILE" "$BACKUP_DIR/settings.json"
+    echo "  - Settings backed up."
+  else
+    echo "  - Settings file not found: $SETTINGS_FILE"
+  fi
+
+  # Backup keybindings
+  if [ -f "$KEYBINDINGS_FILE" ]; then
+    cp "$KEYBINDINGS_FILE" "$BACKUP_DIR/keybindings.json"
+    echo "  - Keybindings backed up."
+  else
+    echo "  - Keybindings file not found: $KEYBINDINGS_FILE"
+  fi
+
+  # Backup extensions list
+  code --list-extensions > "$EXTENSIONS_FILE"
+  echo "  - Extensions list backed up to $EXTENSIONS_FILE."
+
+  # Backup JavaScript snippets (example)
+  if [ -f "$JAVASCRIPT_SNIPPETS" ]; then
+    cp "$JAVASCRIPT_SNIPPETS" "$BACKUP_DIR/javascript.json"
+    echo "  - JavaScript snippets backed up."
+  else
+    echo "  - JavaScript snippets file not found: $JAVASCRIPT_SNIPPETS"
+  fi
+
+  echo "Backup complete."
+}
+
+restore_config() {
+  echo "Restoring VS Code configuration from $BACKUP_DIR..."
+
+  # Restore settings
+  if [ -f "$BACKUP_DIR/settings.json" ]; then
+    cp "$BACKUP_DIR/settings.json" "$SETTINGS_FILE"
+    echo "  - Settings restored."
+  else
+    echo "  - Settings backup not found."
+  fi
+
+  # Restore keybindings
+  if [ -f "$BACKUP_DIR/keybindings.json" ]; then
+    cp "$BACKUP_DIR/keybindings.json" "$KEYBINDINGS_FILE"
+    echo "  - Keybindings restored."
+  else
+    echo "  - Keybindings backup not found."
+  fi
+
+  # Restore extensions
+  if [ -f "$EXTENSIONS_FILE" ]; then
+    echo "  - Installing extensions from $EXTENSIONS_FILE..."
+    cat "$EXTENSIONS_FILE" | xargs -L 1 code --install-extension
+    echo "  - Extensions restored.  VS Code restart may be required."
+  else
+    echo "  - Extensions list backup not found."
+  fi
+
+  # Restore JavaScript snippets (example)
+  if [ -f "$BACKUP_DIR/javascript.json" ]; then
+    cp "$BACKUP_DIR/javascript.json" "$JAVASCRIPT_SNIPPETS"
+    echo "  - JavaScript snippets restored."
+  else
+    echo "  - JavaScript snippets backup not found."
+  fi
+  echo "Restore complete."
+}
+
+# --- Main Script ---
+
+if [ "$1" == "backup" ]; then
+  backup_config
+elif [ "$1" == "restore" ]; then
+  restore_config
+else
+  echo "Usage: $0 [backup|restore]"
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- Added a new script for backing up and restoring VS Code configuration
- Supports both macOS and Linux with automatic OS detection
- Backs up settings, keybindings, extensions list, and snippets

## Test plan
- [ ] Run `./vscode-config-mgmt/vscode-config-mgmt.sh backup` to create a backup
- [ ] Verify backup files are created in `~/Documents/vscode_backup/`
- [ ] Run `./vscode-config-mgmt/vscode-config-mgmt.sh restore` to test restoration
- [ ] Test on both macOS and Linux systems if possible

🤖 Generated with [Claude Code](https://claude.ai/code)